### PR TITLE
generate contracts for all years up to and including current year

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,14 +14,14 @@ build: dataset
 
 dataset:
 	@echo "Assembling players and contracts dataset..."
-	$(PYTHON) -m $(CONTRACTS_DATASET_FILE) --start-year 2011 --end-year 2025
+	$(PYTHON) -m $(CONTRACTS_DATASET_FILE) --start-year 2011 --end-year $(shell date +%Y)
 	@echo "Assembling stats dataset..."
 	$(PYTHON) -m $(STATS_DATASET_FILE)
 	@echo "Full dataset assembly complete."
 
 dataset-auto:
 	@echo "Assembling players and contracts dataset (non-interactive)..."
-	$(PYTHON) -m $(CONTRACTS_DATASET_FILE) --start-year 2011 --end-year 2025 --non-interactive
+	$(PYTHON) -m $(CONTRACTS_DATASET_FILE) --start-year 2011 --end-year $(shell date +%Y) --non-interactive
 	@echo "Assembling stats dataset..."
 	$(PYTHON) -m $(STATS_DATASET_FILE)
 	@echo "Joining contracts with stats..."


### PR DESCRIPTION
### Problem
The Makefile hardcoded `--end-year 2025` for the spotrac scraper, preventing 2026 contracts from being collected.                                            
                                                                                                                                                             
#### Before
```
$(PYTHON) -m $(CONTRACTS_DATASET_FILE) --start-year 2011 --end-year 2025                                                                                   
```

This caused contracts_spotrac.csv and players.csv to remain stuck at August 2025 data, even though the cron job ran daily.

#### Solution
Changed to dynamic year using $(shell date +%Y):

#### After
```
$(PYTHON) -m $(CONTRACTS_DATASET_FILE) --start-year 2011 --end-year $(shell date +%Y)
```

### Verification
Ran `make dataset-auto` and confirmed:

1. Command now includes --end-year 2026 (`.venv/bin/python -m data_generation.spotrac --start-year 2011 --end-year 2026 --non-interactive`)
2. Years 2011-2025 correctly skipped (already in dataset, not current year)
3. 2026 contracts are being scraped and players mapped

```
[SPOTRAC DATA GENERATION]: Spotrac Name: Paul Skenes
[SPOTRAC DATA GENERATION]: Spotrac Name: Pete Crow-Armstrong
```