### PR TITLE
Add a local web chat frontend for the prediction agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CONTRACTS_DATASET_FILE = data_generation.spotrac
 STATS_DATASET_FILE = data_generation.stats
 ANALYSIS_FILE = analysis/contract_analysis.py
 
-.PHONY: dataset dataset-auto analyze review-queue join predict ask backtest-agent test-agent
+.PHONY: dataset dataset-auto analyze review-queue join predict ask backtest-agent test-agent web
 
 build: dataset
 
@@ -55,3 +55,8 @@ backtest-agent:
 
 test-agent:
 	$(PYTHON) -m pytest agent -q
+
+# Basic local chat frontend over the orchestrator agent (see web/server.py).
+# Open http://localhost:8000/ once running.
+web:
+	$(PYTHON) -m uvicorn web.server:app --reload --port 8000

--- a/agent/orchestrator/agent.py
+++ b/agent/orchestrator/agent.py
@@ -7,6 +7,7 @@ its own fresh agent internally, so prediction reproducibility is unaffected.
 """
 
 import os
+import re
 import sys
 
 from agent.config import DEFAULT_MODEL_ID, model_params
@@ -25,6 +26,15 @@ MAX_CONVERSATION_TURNS = 50
 
 # Follow-up prompt replies that end the conversation instead of starting a new turn.
 EXIT_INPUTS = {"", "quit", "exit", "no", "nope", "nothing", "no thanks", "bye", "done"}
+
+# Matches a `message` that starts like raw JSON rather than prose.
+_JSON_LIKE_RE = re.compile(r"^\s*[\{\[]")
+
+_JSON_LEAK_NUDGE = (
+    "Your last reply's `message` looked like raw JSON, not natural language. Rewrite it as a "
+    "normal conversational sentence/paragraph for a person to read -- no braces, no key: value "
+    "syntax, no code fences -- describing the same information in words."
+)
 
 
 def _import_strands():
@@ -59,6 +69,29 @@ def create_orchestrator_agent(model_id=None):
     )
 
 
+def get_turn(agent, text, _retried=False):
+    """Run one orchestrator turn and return its OrchestratorTurn.
+
+    Guards against a real failure mode observed live (July 2026, gpt-5-mini):
+    despite the system prompt's explicit "never show raw JSON" instruction,
+    the model occasionally serializes predict_tool's structured result
+    straight into `message` instead of paraphrasing it in prose. One
+    corrective retry on the same persistent agent (so full context is kept)
+    before giving up and returning whatever we got -- prompt text alone
+    wasn't reliable enough here, same lesson as the no-lookahead/service_time
+    guards elsewhere in this codebase: correctness-critical behavior gets a
+    code-level check, not just a prompt request.
+
+    Shared by both the CLI loop (run_conversation, below) and web/server.py's
+    one-turn-per-request handler, so the guard applies in both places.
+    """
+    result = agent(text, structured_output_model=OrchestratorTurn)
+    turn = result.structured_output
+    if not _retried and _JSON_LIKE_RE.match(turn.message):
+        return get_turn(agent, _JSON_LEAK_NUDGE, _retried=True)
+    return turn
+
+
 def run_conversation(initial_request, model_id=None, ask_fn=input, agent=None):
     """Drive the conversation to completion, including follow-up questions.
 
@@ -80,8 +113,7 @@ def run_conversation(initial_request, model_id=None, ask_fn=input, agent=None):
     clarification_streak = 0
 
     for _ in range(MAX_CONVERSATION_TURNS):
-        result = agent(text, structured_output_model=OrchestratorTurn)
-        turn = result.structured_output
+        turn = get_turn(agent, text)
         turns.append({"user": text, "message": turn.message, "done": turn.done})
         print(turn.message)
 

--- a/agent/orchestrator/agent.py
+++ b/agent/orchestrator/agent.py
@@ -51,8 +51,13 @@ def _import_strands():
     return Agent, OpenAIModel
 
 
-def create_orchestrator_agent(model_id=None):
-    """Create the one persistent Agent for a conversation."""
+def create_orchestrator_agent(model_id=None, extra_hooks=None):
+    """Create the one persistent Agent for a conversation.
+
+    extra_hooks: additional HookProviders appended after the default
+    ToolCallLogger (e.g. web/status.py's StatusHook, for UI progress
+    reporting) -- optional, so the CLI's behavior is unchanged.
+    """
     Agent, OpenAIModel = _import_strands()
 
     if not os.environ.get("OPENAI_API_KEY"):
@@ -65,7 +70,7 @@ def create_orchestrator_agent(model_id=None):
         model=model,
         tools=[intake_tool, predict_tool],
         system_prompt=ORCHESTRATOR_SYSTEM_PROMPT,
-        hooks=[ToolCallLogger()],
+        hooks=[ToolCallLogger(), *(extra_hooks or [])],
     )
 
 

--- a/agent/orchestrator/prompts.py
+++ b/agent/orchestrator/prompts.py
@@ -62,6 +62,13 @@ FLOW:
      plus a one-line highlight of the reasoning.
    Either way, mention that the full reasoning and citations are saved in the trace file if they
    want more detail. Set done=True.
+   HARD RULE on `message` formatting: it must be prose — sentences and paragraphs, the way you'd
+   text a person — never a JSON object/array, never key: value lines, never code fences. This
+   applies even though predict_tool's result IS a JSON structure internally: your job is to
+   describe that structure in words, not to re-serialize or forward it. WRONG:
+   `{"aav_millions": 30.0, "duration_years": 6, ...}`. RIGHT: "I'd project about $30M a year over
+   6 years (~$180M total)." If you catch yourself about to type a `{` to start `message`, stop and
+   rewrite that sentence in words instead.
 
 Never fabricate a player, year, or figure yourself — always go through the tools. If intake needs
 several rounds of clarification, that's expected; keep each `message` to one focused question.

--- a/agent/trace.py
+++ b/agent/trace.py
@@ -89,10 +89,30 @@ def append_history(
     actual_aav=None,
     history_csv=None,
 ):
-    """Append one prediction row to the history CSV (header written if new)."""
+    """Append one prediction row to the history CSV (header written if new).
+
+    Guards against a real corruption found live (July 2026): HISTORY_HEADERS
+    gained a column (no_contract) mid-project, but the header line is only
+    ever written once, when the file doesn't exist yet -- so an existing
+    file's stored header silently stopped matching the rows being appended
+    to it, and every downstream reader (e.g. web/history.py) misaligned
+    every field after the insertion point for every row written since. Loud
+    failure here beats another silent misalignment.
+    """
     history_csv = history_csv or HISTORY_CSV
     history_csv.parent.mkdir(parents=True, exist_ok=True)
-    write_header = not history_csv.exists()
+    write_header = not history_csv.exists() or history_csv.stat().st_size == 0
+    if not write_header:
+        with open(history_csv, newline="") as file:
+            existing_header = next(csv.reader(file), [])
+        if existing_header != HISTORY_HEADERS:
+            raise RuntimeError(
+                f"{history_csv} header {existing_header} doesn't match current "
+                f"HISTORY_HEADERS {HISTORY_HEADERS} -- the schema changed after "
+                "this file was created. Migrate or delete it (it's derived/"
+                "gitignored) before appending, rather than silently misaligning "
+                "every row written from here on."
+            )
     with open(history_csv, mode="a", newline="") as file:
         writer = csv.writer(file)
         if write_header:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 beautifulsoup4==4.13.3
+fastapi>=0.110.0
 openai>=1.0.0
 pandas==2.2.2
 pybaseball==2.2.7
@@ -9,3 +10,4 @@ requests==2.32.3
 seaborn==0.13.2
 scikit-learn==1.5.1
 strands-agents[openai]>=1.32.0
+uvicorn>=0.30.0

--- a/web/history.py
+++ b/web/history.py
@@ -1,0 +1,41 @@
+"""Reads predictions/history.csv for the sidebar's prediction list.
+
+history.csv (agent/trace.py:append_history) already has exactly what a list
+view needs -- one row per prediction with player_id, target_year, phase, the
+predicted figures, and confidence -- written at the same time as each full
+trace JSON, so it's always in sync and far cheaper to read than opening every
+trace file (each of which also carries full message history/token usage,
+useful for a future detail view, not a list).
+
+Plain csv (not pandas) deliberately: every value comes back as a string,
+which sidesteps NaN/numpy-dtype JSON-serialization edge cases entirely for a
+handful of small local files -- the frontend parses numbers itself.
+
+Note: this file also picks up `make backtest-agent` runs, not just
+interactive predictions (agent/predict/predict.py:run_prediction is shared by
+both) -- surfaced as-is for now (see docs), not filtered.
+"""
+
+import csv
+
+from agent.config import HISTORY_CSV, PLAYERS_CSV
+
+
+def _player_names():
+    if not PLAYERS_CSV.exists():
+        return {}
+    with open(PLAYERS_CSV, newline="") as file:
+        return {row["player_id"]: f"{row['first_name']} {row['last_name']}" for row in csv.DictReader(file)}
+
+
+def load_history():
+    """Every prediction row, newest first, with a resolved player_name added."""
+    if not HISTORY_CSV.exists():
+        return []
+    names = _player_names()
+    with open(HISTORY_CSV, newline="") as file:
+        rows = list(csv.DictReader(file))
+    for row in rows:
+        row["player_name"] = names.get(row["player_id"], row["player_id"])
+    rows.reverse()  # file is append-only oldest-first
+    return rows

--- a/web/server.py
+++ b/web/server.py
@@ -34,6 +34,7 @@ from pydantic import BaseModel
 
 from agent.config import DEFAULT_MODEL_ID
 from agent.orchestrator.agent import get_turn
+from web.status import get_status, reset_status, StatusHook
 
 STATIC_DIR = Path(__file__).resolve().parent / "static"
 
@@ -67,20 +68,31 @@ def _get_or_create_agent(session_id):
     from agent.orchestrator.agent import create_orchestrator_agent
 
     new_id = session_id or str(uuid.uuid4())
-    _sessions[new_id] = create_orchestrator_agent(DEFAULT_MODEL_ID)
+    _sessions[new_id] = create_orchestrator_agent(
+        DEFAULT_MODEL_ID, extra_hooks=[StatusHook(new_id)]
+    )
     return new_id, _sessions[new_id]
 
 
 @app.get("/")
 def index():
-    return FileResponse(STATIC_DIR / "index.html")
+    # No-store: this is actively edited during local dev and a stale cached
+    # copy in the browser silently masks frontend changes (the dev server's
+    # --reload only restarts the backend, it can't refresh an open tab).
+    return FileResponse(STATIC_DIR / "index.html", headers={"Cache-Control": "no-store"})
 
 
 @app.post("/api/chat", response_model=ChatResponse)
 def chat(req: ChatRequest):
     session_id, agent = _get_or_create_agent(req.session_id)
+    reset_status(session_id)
     turn = get_turn(agent, req.message)
     return ChatResponse(session_id=session_id, message=turn.message, done=turn.done)
+
+
+@app.get("/api/status")
+def status(session_id: str):
+    return {"status": get_status(session_id)}
 
 
 @app.post("/api/reset")

--- a/web/server.py
+++ b/web/server.py
@@ -34,6 +34,7 @@ from pydantic import BaseModel
 
 from agent.config import DEFAULT_MODEL_ID
 from agent.orchestrator.agent import get_turn
+from web.history import load_history
 from web.status import get_status, reset_status, StatusHook
 
 STATIC_DIR = Path(__file__).resolve().parent / "static"
@@ -93,6 +94,11 @@ def chat(req: ChatRequest):
 @app.get("/api/status")
 def status(session_id: str):
     return {"status": get_status(session_id)}
+
+
+@app.get("/api/history")
+def history():
+    return {"predictions": load_history()}
 
 
 @app.post("/api/reset")

--- a/web/server.py
+++ b/web/server.py
@@ -36,6 +36,7 @@ from agent.config import DEFAULT_MODEL_ID
 from agent.orchestrator.agent import get_turn
 from web.history import load_history
 from web.status import get_status, reset_status, StatusHook
+from web.traces import load_trace_summary
 
 STATIC_DIR = Path(__file__).resolve().parent / "static"
 
@@ -99,6 +100,14 @@ def status(session_id: str):
 @app.get("/api/history")
 def history():
     return {"predictions": load_history()}
+
+
+@app.get("/api/trace/{run_id}")
+def trace_detail(run_id: str):
+    summary = load_trace_summary(run_id)
+    if summary is None:
+        raise HTTPException(status_code=404, detail="Trace not found")
+    return summary
 
 
 @app.post("/api/reset")

--- a/web/server.py
+++ b/web/server.py
@@ -1,0 +1,89 @@
+"""Very basic local chat server over the orchestrator agent.
+
+Deliberately lives outside agent/ -- this is a consumer of the agent package
+(same relationship agent/ask.py's CLI has), not part of its business logic.
+
+One-turn-per-HTTP-request adapter around agent/orchestrator/agent.py: the
+orchestrator is the one persistent (non-fresh) agent in the system (Design
+Decision #7 in docs/agent/DESIGN.md), so each browser session gets its own
+long-lived Agent instance, kept in an in-memory dict keyed by a session_id
+the frontend generates once and resends with every message.
+
+Deliberately minimal for a first local pass:
+- In-memory sessions only -- lost on server restart, no multi-worker support.
+- No auth, no rate limiting, no HTTPS -- localhost use only.
+- No per-session turn/clarification-streak caps (see MAX_TURNS /
+  MAX_CONVERSATION_TURNS in orchestrator/agent.py's CLI loop) -- a long
+  confused conversation just keeps calling the LLM. Fine for local testing;
+  revisit before this is anything but a local dev tool.
+- No incremental conversation-trace persistence -- agent/ask.py writes a
+  trace at the end of a CLI conversation; this server doesn't write one at
+  all yet (a session that's abandoned mid-conversation just disappears).
+
+Run with: make web  (see Makefile), then open http://localhost:8000/
+"""
+
+import os
+import uuid
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+
+from agent.config import DEFAULT_MODEL_ID
+from agent.orchestrator.agent import get_turn
+
+STATIC_DIR = Path(__file__).resolve().parent / "static"
+
+app = FastAPI(title="MLB Contract Prediction Chat")
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+
+# session_id -> live orchestrator Agent instance (see module docstring)
+_sessions = {}
+
+
+class ChatRequest(BaseModel):
+    message: str
+    session_id: str | None = None
+
+
+class ChatResponse(BaseModel):
+    session_id: str
+    message: str
+    done: bool
+
+
+def _get_or_create_agent(session_id):
+    if session_id and session_id in _sessions:
+        return session_id, _sessions[session_id]
+
+    if not os.environ.get("OPENAI_API_KEY"):
+        raise HTTPException(
+            status_code=500,
+            detail="OPENAI_API_KEY not set (checked .env at repo root).",
+        )
+    from agent.orchestrator.agent import create_orchestrator_agent
+
+    new_id = session_id or str(uuid.uuid4())
+    _sessions[new_id] = create_orchestrator_agent(DEFAULT_MODEL_ID)
+    return new_id, _sessions[new_id]
+
+
+@app.get("/")
+def index():
+    return FileResponse(STATIC_DIR / "index.html")
+
+
+@app.post("/api/chat", response_model=ChatResponse)
+def chat(req: ChatRequest):
+    session_id, agent = _get_or_create_agent(req.session_id)
+    turn = get_turn(agent, req.message)
+    return ChatResponse(session_id=session_id, message=turn.message, done=turn.done)
+
+
+@app.post("/api/reset")
+def reset(session_id: str):
+    _sessions.pop(session_id, None)
+    return {"ok": True}

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>MLB Contract Prediction Chat</title>
+<style>
+  body { font-family: -apple-system, sans-serif; max-width: 700px; margin: 2rem auto; padding: 0 1rem; }
+  #log { border: 1px solid #ccc; border-radius: 8px; padding: 1rem; height: 60vh; overflow-y: auto; margin-bottom: 1rem; }
+  .msg { margin: 0.5rem 0; white-space: pre-wrap; }
+  .user { color: #0645ad; }
+  .assistant { color: #222; }
+  .user b, .assistant b { display: inline-block; min-width: 4.5rem; }
+  form { display: flex; gap: 0.5rem; }
+  input[type=text] { flex: 1; padding: 0.5rem; font-size: 1rem; }
+  button { padding: 0.5rem 1rem; font-size: 1rem; }
+  #status { color: #888; font-size: 0.9rem; margin-bottom: 0.5rem; min-height: 1.2em; }
+</style>
+</head>
+<body>
+<h2>MLB Contract Prediction Chat</h2>
+<p>Ask about a player's projected or actual contract, e.g. "what will Corbin Burnes make in 2026?"</p>
+<div id="log"></div>
+<div id="status"></div>
+<form id="form">
+  <input id="input" type="text" autocomplete="off" placeholder="Ask a question..." autofocus>
+  <button type="submit">Send</button>
+</form>
+
+<script>
+let sessionId = null;
+const log = document.getElementById("log");
+const status = document.getElementById("status");
+const form = document.getElementById("form");
+const input = document.getElementById("input");
+
+function addMessage(role, text) {
+  const div = document.createElement("div");
+  div.className = "msg " + role;
+  div.innerHTML = "<b>" + (role === "user" ? "You" : "Assistant") + ":</b> " + text.replace(/</g, "&lt;");
+  log.appendChild(div);
+  log.scrollTop = log.scrollHeight;
+}
+
+form.addEventListener("submit", async (e) => {
+  e.preventDefault();
+  const text = input.value.trim();
+  if (!text) return;
+  addMessage("user", text);
+  input.value = "";
+  input.disabled = true;
+  status.textContent = "Thinking...";
+
+  try {
+    const resp = await fetch("/api/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: text, session_id: sessionId }),
+    });
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({}));
+      addMessage("assistant", "Error: " + (err.detail || resp.statusText));
+      return;
+    }
+    const data = await resp.json();
+    sessionId = data.session_id;
+    addMessage("assistant", data.message);
+  } catch (err) {
+    addMessage("assistant", "Error: " + err);
+  } finally {
+    status.textContent = "";
+    input.disabled = false;
+    input.focus();
+  }
+});
+</script>
+</body>
+</html>

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -27,7 +27,9 @@
 </form>
 
 <script>
-let sessionId = null;
+// Generated once up front (not waited on from the server) so the very first
+// message already has a session_id to poll /api/status with.
+let sessionId = crypto.randomUUID();
 const log = document.getElementById("log");
 const status = document.getElementById("status");
 const form = document.getElementById("form");
@@ -50,6 +52,22 @@ form.addEventListener("submit", async (e) => {
   input.disabled = true;
   status.textContent = "Thinking...";
 
+  // Poll the phase-aware status endpoint while the chat request is in
+  // flight (intake_tool -> "Looking up player...", predict_tool -> "Making
+  // prediction...", anything else -> the "Thinking..." fallback).
+  const pollStatus = async () => {
+    try {
+      const resp = await fetch("/api/status?session_id=" + encodeURIComponent(sessionId));
+      if (resp.ok) {
+        const data = await resp.json();
+        status.textContent = data.status;
+      }
+    } catch (err) {
+      // Non-fatal -- the status line is a nicety, not required for the answer.
+    }
+  };
+  const statusInterval = setInterval(pollStatus, 400);
+
   try {
     const resp = await fetch("/api/chat", {
       method: "POST",
@@ -67,6 +85,7 @@ form.addEventListener("submit", async (e) => {
   } catch (err) {
     addMessage("assistant", "Error: " + err);
   } finally {
+    clearInterval(statusInterval);
     status.textContent = "";
     input.disabled = false;
     input.focus();

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -2,25 +2,190 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>MLB Contract Prediction Chat</title>
 <style>
-  body { font-family: -apple-system, sans-serif; max-width: 700px; margin: 2rem auto; padding: 0 1rem; }
-  #log { border: 1px solid #ccc; border-radius: 8px; padding: 1rem; height: 60vh; overflow-y: auto; margin-bottom: 1rem; }
-  .msg { margin: 0.5rem 0; white-space: pre-wrap; }
-  .user { color: #0645ad; }
-  .assistant { color: #222; }
-  .user b, .assistant b { display: inline-block; min-width: 4.5rem; }
-  form { display: flex; gap: 0.5rem; }
-  input[type=text] { flex: 1; padding: 0.5rem; font-size: 1rem; }
-  button { padding: 0.5rem 1rem; font-size: 1rem; }
-  #status { color: #888; font-size: 0.9rem; margin-bottom: 0.5rem; min-height: 1.2em; }
+  :root {
+    --bg: #faf9f7;
+    --panel: #ffffff;
+    --text: #1b1d1e;
+    --text-muted: #6b7280;
+    --border: #e6e3dd;
+    --accent: #1f6f5c;
+    --assistant-bubble: #f0f1ef;
+    --assistant-text: #1b1d1e;
+    --user-bubble: var(--accent);
+    --user-text: #ffffff;
+    --error: #b3261e;
+    --error-bubble: #fbeae8;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #121416;
+      --panel: #17191b;
+      --text: #ecedee;
+      --text-muted: #9aa0a6;
+      --border: #2a2d2f;
+      --accent: #3fa98a;
+      --assistant-bubble: #23262a;
+      --assistant-text: #ecedee;
+      --user-bubble: var(--accent);
+      --user-text: #08130f;
+      --error: #ff8a80;
+      --error-bubble: #3a1f1d;
+    }
+  }
+
+  * { box-sizing: border-box; }
+  html, body {
+    height: 100%;
+    margin: 0;
+  }
+  body {
+    display: flex;
+    flex-direction: column;
+    background: var(--bg);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, Roboto, sans-serif;
+  }
+
+  header {
+    padding: 1.1rem 1.5rem 0.9rem;
+    border-bottom: 1px solid var(--border);
+    background: var(--panel);
+  }
+  header h1 {
+    margin: 0;
+    font-family: ui-serif, Georgia, "Times New Roman", serif;
+    font-size: 1.3rem;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+  }
+  header p {
+    margin: 0.25rem 0 0;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+  }
+
+  #log {
+    flex: 1;
+    overflow-y: auto;
+    padding: 1.25rem 1rem;
+    max-width: 720px;
+    width: 100%;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+  }
+
+  .row {
+    display: flex;
+    width: 100%;
+  }
+  .row.user { justify-content: flex-end; }
+  .row.assistant { justify-content: flex-start; }
+
+  .bubble {
+    max-width: 75%;
+    padding: 0.65rem 0.95rem;
+    font-size: 0.95rem;
+    line-height: 1.45;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+  }
+  .row.user .bubble {
+    background: var(--user-bubble);
+    color: var(--user-text);
+    border-radius: 18px 18px 4px 18px;
+  }
+  .row.assistant .bubble {
+    background: var(--assistant-bubble);
+    color: var(--assistant-text);
+    border-radius: 18px 18px 18px 4px;
+  }
+  .row.assistant .bubble.error {
+    background: var(--error-bubble);
+    color: var(--error);
+  }
+
+  /* Typing indicator: sits where the reply will land, phase caption above
+     three dots that bounce in sequence (iMessage-style). */
+  .typing-caption {
+    display: block;
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    margin-bottom: 0.3rem;
+    min-height: 1em;
+  }
+  .dots {
+    display: inline-flex;
+    gap: 0.28rem;
+    align-items: center;
+    height: 0.9rem;
+  }
+  .dots span {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--text-muted);
+    animation: bounce 1.2s infinite ease-in-out;
+  }
+  .dots span:nth-child(2) { animation-delay: 0.15s; }
+  .dots span:nth-child(3) { animation-delay: 0.3s; }
+  @keyframes bounce {
+    0%, 60%, 100% { transform: translateY(0); opacity: 0.5; }
+    30% { transform: translateY(-4px); opacity: 1; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .dots span { animation: none; opacity: 0.7; }
+  }
+
+  form {
+    display: flex;
+    gap: 0.6rem;
+    padding: 0.85rem 1rem;
+    border-top: 1px solid var(--border);
+    background: var(--panel);
+    max-width: 720px;
+    width: 100%;
+    margin: 0 auto;
+  }
+  input[type=text] {
+    flex: 1;
+    padding: 0.65rem 0.9rem;
+    font-size: 0.95rem;
+    border: 1px solid var(--border);
+    border-radius: 20px;
+    background: var(--bg);
+    color: var(--text);
+    outline: none;
+  }
+  input[type=text]:focus {
+    border-color: var(--accent);
+  }
+  button {
+    padding: 0.6rem 1.15rem;
+    font-size: 0.95rem;
+    font-weight: 600;
+    border: none;
+    border-radius: 20px;
+    background: var(--accent);
+    color: var(--user-text);
+    cursor: pointer;
+  }
+  button:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
 </style>
 </head>
 <body>
-<h2>MLB Contract Prediction Chat</h2>
-<p>Ask about a player's projected or actual contract, e.g. "what will Corbin Burnes make in 2026?"</p>
+<header>
+  <h1>MLB Contract Prediction Chat</h1>
+  <p>Ask about a player's projected or actual contract, e.g. "what will Corbin Burnes make in 2026?"</p>
+</header>
 <div id="log"></div>
-<div id="status"></div>
 <form id="form">
   <input id="input" type="text" autocomplete="off" placeholder="Ask a question..." autofocus>
   <button type="submit">Send</button>
@@ -31,39 +196,56 @@
 // message already has a session_id to poll /api/status with.
 let sessionId = crypto.randomUUID();
 const log = document.getElementById("log");
-const status = document.getElementById("status");
 const form = document.getElementById("form");
 const input = document.getElementById("input");
+const button = form.querySelector("button");
 
-function addMessage(role, text) {
-  const div = document.createElement("div");
-  div.className = "msg " + role;
-  div.innerHTML = "<b>" + (role === "user" ? "You" : "Assistant") + ":</b> " + text.replace(/</g, "&lt;");
-  log.appendChild(div);
+function addBubble(role, text) {
+  const row = document.createElement("div");
+  row.className = "row " + role;
+  const bubble = document.createElement("div");
+  bubble.className = "bubble";
+  bubble.textContent = text;
+  row.appendChild(bubble);
+  log.appendChild(row);
   log.scrollTop = log.scrollHeight;
+  return bubble;
+}
+
+function addTypingBubble() {
+  const row = document.createElement("div");
+  row.className = "row assistant";
+  row.innerHTML =
+    '<div class="bubble">' +
+    '  <span class="typing-caption">Thinking...</span>' +
+    '  <span class="dots"><span></span><span></span><span></span></span>' +
+    "</div>";
+  log.appendChild(row);
+  log.scrollTop = log.scrollHeight;
+  return row;
 }
 
 form.addEventListener("submit", async (e) => {
   e.preventDefault();
   const text = input.value.trim();
   if (!text) return;
-  addMessage("user", text);
+  addBubble("user", text);
   input.value = "";
   input.disabled = true;
-  status.textContent = "Thinking...";
+  button.disabled = true;
 
-  // Poll the phase-aware status endpoint while the chat request is in
-  // flight (intake_tool -> "Looking up player...", predict_tool -> "Making
-  // prediction...", anything else -> the "Thinking..." fallback).
+  const typingRow = addTypingBubble();
+  const caption = typingRow.querySelector(".typing-caption");
+
   const pollStatus = async () => {
     try {
       const resp = await fetch("/api/status?session_id=" + encodeURIComponent(sessionId));
       if (resp.ok) {
         const data = await resp.json();
-        status.textContent = data.status;
+        caption.textContent = data.status;
       }
     } catch (err) {
-      // Non-fatal -- the status line is a nicety, not required for the answer.
+      // Non-fatal -- the status caption is a nicety, not required for the answer.
     }
   };
   const statusInterval = setInterval(pollStatus, 400);
@@ -74,20 +256,22 @@ form.addEventListener("submit", async (e) => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ message: text, session_id: sessionId }),
     });
+    typingRow.remove();
     if (!resp.ok) {
       const err = await resp.json().catch(() => ({}));
-      addMessage("assistant", "Error: " + (err.detail || resp.statusText));
+      addBubble("assistant", "Error: " + (err.detail || resp.statusText)).classList.add("error");
       return;
     }
     const data = await resp.json();
     sessionId = data.session_id;
-    addMessage("assistant", data.message);
+    addBubble("assistant", data.message);
   } catch (err) {
-    addMessage("assistant", "Error: " + err);
+    typingRow.remove();
+    addBubble("assistant", "Error: " + err).classList.add("error");
   } finally {
     clearInterval(statusInterval);
-    status.textContent = "";
     input.disabled = false;
+    button.disabled = false;
     input.focus();
   }
 });

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -47,12 +47,193 @@
     height: 100%;
     margin: 0;
   }
+
+  /* Scrollbars in the scorebook palette instead of the default OS gray/white. */
+  html {
+    scrollbar-width: thin;
+    scrollbar-color: var(--border) transparent;
+  }
+  ::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  ::-webkit-scrollbar-thumb {
+    background-color: var(--border);
+    border-radius: 8px;
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    background-color: var(--accent-2);
+  }
   body {
     display: flex;
     flex-direction: column;
     background: var(--bg);
     color: var(--text);
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, Roboto, sans-serif;
+  }
+
+  /* Everything below the header: sidebar + chat side by side. */
+  .body-row {
+    flex: 1;
+    display: flex;
+    flex-direction: row;
+    min-height: 0;
+    position: relative;
+  }
+
+  /* A tab that appears to fold out of the sidebar's edge, just under the
+     headers -- tracks the sidebar's right edge as it collapses/expands so it
+     always stays reachable, even with the sidebar fully hidden. */
+  .sidebar-handle {
+    position: absolute;
+    top: 3.9rem;
+    left: 279px;
+    z-index: 5;
+    width: 20px;
+    height: 44px;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--border);
+    border-left: none;
+    border-radius: 0 10px 10px 0;
+    background: var(--panel);
+    color: var(--text-muted);
+    font-size: 0.85rem;
+    line-height: 1;
+    cursor: pointer;
+    transition: left 0.28s ease, background-color 0.15s ease, color 0.15s ease;
+  }
+  .sidebar-handle:hover {
+    background: var(--bg);
+    color: var(--text);
+  }
+  body.sidebar-collapsed .sidebar-handle {
+    left: 0;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .sidebar-handle { transition: none; }
+  }
+  @media (max-width: 760px) {
+    .sidebar-handle { display: none; }
+  }
+
+  .chat {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  /* Sidebar: the running list of every prediction the agent has generated
+     (predictions/history.csv), newest first. A fresh entry (found on a poll
+     that wasn't there before) pops in at the top -- see .history-item.is-new. */
+  aside {
+    width: 280px;
+    flex-shrink: 0;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    background: var(--panel);
+    border-right: 1px solid var(--border);
+    overflow: hidden;
+    transition: width 0.28s ease, border-color 0.28s ease;
+  }
+  body.sidebar-collapsed aside {
+    width: 0;
+    border-right-color: transparent;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    aside { transition: none; }
+  }
+  aside h2 {
+    margin: 0;
+    padding: 1.1rem 1.1rem 0.7rem;
+    font-family: ui-serif, Georgia, "Times New Roman", serif;
+    font-size: 1rem;
+    font-weight: 600;
+    border-bottom: 1px solid var(--border);
+    white-space: nowrap;
+  }
+  #history-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0.7rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .history-empty {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+    padding: 0.5rem;
+    line-height: 1.4;
+  }
+  .history-item {
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 0.55rem 0.7rem;
+    font-size: 0.82rem;
+    line-height: 1.4;
+    background: var(--bg);
+  }
+  .hi-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 0.4rem;
+    font-weight: 600;
+  }
+  .hi-player {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .hi-year {
+    color: var(--text-muted);
+    font-weight: 500;
+    flex-shrink: 0;
+  }
+  .hi-figures {
+    margin-top: 0.15rem;
+    color: var(--text);
+  }
+  .hi-bottom {
+    margin-top: 0.3rem;
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    text-transform: capitalize;
+  }
+  .conf-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+  .conf-dot.high { background: var(--accent); }
+  .conf-dot.medium { background: var(--accent-2); }
+  .conf-dot.low { background: var(--text-muted); }
+  @keyframes popIn {
+    from {
+      transform: translateY(-10px);
+      opacity: 0;
+      background: color-mix(in srgb, var(--accent-2) 30%, var(--bg));
+    }
+    to { transform: translateY(0); opacity: 1; }
+  }
+  .history-item.is-new { animation: popIn 0.6s ease-out; }
+  @media (prefers-reduced-motion: reduce) {
+    .history-item.is-new { animation: none; }
+  }
+  @media (max-width: 760px) {
+    aside { display: none; }
   }
 
   header {
@@ -71,6 +252,20 @@
     margin: 0.25rem 0 0;
     font-size: 0.85rem;
     color: var(--text-muted);
+  }
+
+  .chat-header {
+    display: flex;
+    align-items: center;
+    padding: 1.1rem 1.1rem 0.7rem;
+    border-bottom: 1px solid var(--border);
+    background: var(--panel);
+  }
+  .chat-header h2 {
+    margin: 0;
+    font-family: ui-serif, Georgia, "Times New Roman", serif;
+    font-size: 1rem;
+    font-weight: 600;
   }
 
   #log {
@@ -201,11 +396,23 @@
   <h1>MLB Contract Prediction Chat</h1>
   <p>Ask about a player's projected or actual contract, e.g. "what will Corbin Burnes make in 2026?"</p>
 </header>
-<div id="log"></div>
-<form id="form">
-  <input id="input" type="text" autocomplete="off" placeholder="Ask a question..." autofocus>
-  <button type="submit">Send</button>
-</form>
+<div class="body-row">
+  <aside>
+    <h2>Predictions</h2>
+    <div id="history-list"></div>
+  </aside>
+  <button id="sidebar-toggle" class="sidebar-handle" type="button" aria-label="Hide predictions sidebar" aria-expanded="true">‹</button>
+  <main class="chat">
+    <div class="chat-header">
+      <h2>Chat</h2>
+    </div>
+    <div id="log"></div>
+    <form id="form">
+      <input id="input" type="text" autocomplete="off" placeholder="Ask a question..." autofocus>
+      <button type="submit">Send</button>
+    </form>
+  </main>
+</div>
 
 <script>
 // Generated once up front (not waited on from the server) so the very first
@@ -215,6 +422,14 @@ const log = document.getElementById("log");
 const form = document.getElementById("form");
 const input = document.getElementById("input");
 const button = form.querySelector("button");
+
+const sidebarToggle = document.getElementById("sidebar-toggle");
+sidebarToggle.addEventListener("click", () => {
+  const collapsed = document.body.classList.toggle("sidebar-collapsed");
+  sidebarToggle.textContent = collapsed ? "›" : "‹";
+  sidebarToggle.setAttribute("aria-expanded", String(!collapsed));
+  sidebarToggle.setAttribute("aria-label", collapsed ? "Show predictions sidebar" : "Hide predictions sidebar");
+});
 
 function addBubble(role, text) {
   const row = document.createElement("div");
@@ -227,6 +442,75 @@ function addBubble(role, text) {
   log.scrollTop = log.scrollHeight;
   return bubble;
 }
+
+// --- Sidebar: predictions/history.csv, newest first, polled so entries
+// created by ANY process (this session, another `make ask`/`make predict`
+// run, a backtest) show up, not just this tab's own predictions. ---
+const historyList = document.getElementById("history-list");
+let knownRunIds = null; // null until the first successful load
+
+function formatFigures(p) {
+  if (p.no_contract === "True") return "No contract expected";
+  const aav = parseFloat(p.predicted_aav);
+  const dur = parseInt(p.predicted_duration, 10);
+  if (Number.isNaN(aav) || Number.isNaN(dur)) return "—";
+  return "$" + aav.toFixed(1) + "M AAV · " + dur + (dur === 1 ? " yr" : " yrs");
+}
+
+function formatDate(isoString) {
+  const d = new Date(isoString);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function renderHistory(predictions) {
+  const isFirstLoad = knownRunIds === null;
+  const nextKnown = new Set();
+  historyList.innerHTML = "";
+
+  if (predictions.length === 0) {
+    historyList.innerHTML = '<div class="history-empty">No predictions yet — ask a question to get started.</div>';
+  }
+
+  for (const p of predictions) {
+    nextKnown.add(p.run_id);
+    const item = document.createElement("div");
+    item.className = "history-item";
+    if (!isFirstLoad && knownRunIds && !knownRunIds.has(p.run_id)) {
+      item.classList.add("is-new");
+    }
+    const confidence = (p.confidence || "").toLowerCase() || "medium";
+    item.innerHTML =
+      '<div class="hi-top">' +
+      '  <span class="hi-player">' + (p.player_name || p.player_id) + "</span>" +
+      '  <span class="hi-year">' + p.target_year + "</span>" +
+      "</div>" +
+      '<div class="hi-figures">' + formatFigures(p) + "</div>" +
+      '<div class="hi-bottom">' +
+      '  <span class="conf-dot ' + confidence + '"></span>' +
+      "  <span>" + (p.phase || "") + "</span>" +
+      "  <span>·</span>" +
+      "  <span>" + formatDate(p.run_date) + "</span>" +
+      "</div>";
+    historyList.appendChild(item);
+  }
+  knownRunIds = nextKnown;
+}
+
+async function refreshHistory() {
+  try {
+    const resp = await fetch("/api/history");
+    if (resp.ok) {
+      const data = await resp.json();
+      renderHistory(data.predictions);
+    }
+  } catch (err) {
+    // Non-fatal -- the sidebar is a nicety, not required for the chat itself.
+  }
+}
+
+refreshHistory();
+setInterval(refreshHistory, 5000);
 
 function addTypingBubble() {
   const row = document.createElement("div");
@@ -281,6 +565,7 @@ form.addEventListener("submit", async (e) => {
     const data = await resp.json();
     sessionId = data.session_id;
     addBubble("assistant", data.message);
+    refreshHistory();
   } catch (err) {
     typingRow.remove();
     addBubble("assistant", "Error: " + err).classList.add("error");

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -308,6 +308,9 @@
     white-space: pre-wrap;
     word-wrap: break-word;
   }
+  .bubble p { margin: 0; }
+  .bubble p + p { margin-top: 0.5rem; }
+  .bubble .reasoning-list { margin-top: 0.45rem; }
   .row.user .bubble {
     background: var(--user-bubble);
     color: var(--user-text);
@@ -679,7 +682,12 @@ function addBubble(role, text) {
   row.className = "row " + role;
   const bubble = document.createElement("div");
   bubble.className = "bubble";
-  bubble.textContent = text;
+  // Same paragraph/bullet-list formatting as the trace popup's reasoning --
+  // a follow-up reply can carry the same dense inline-bulleted text
+  // ("... - Label: detail - Label: detail"). formatReasoning escapes every
+  // piece of text it inserts, so this is as safe as the textContent it
+  // replaces despite now using innerHTML.
+  bubble.innerHTML = formatReasoning(text);
   row.appendChild(bubble);
   log.appendChild(row);
   log.scrollTop = log.scrollHeight;

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -5,15 +5,20 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>MLB Contract Prediction Chat</title>
 <style>
+  /* "Scorebook" palette: pale sage ledger paper + ink navy, in the spirit of
+     an old scorecard, with pine green (grass) as the primary accent and a
+     dirt terracotta as a sparing secondary accent (stitching, bubble tabs,
+     the typing indicator) -- never the dominant color. */
   :root {
-    --bg: #faf9f7;
-    --panel: #ffffff;
-    --text: #1b1d1e;
-    --text-muted: #6b7280;
-    --border: #e6e3dd;
+    --bg: #eef2e7;
+    --panel: #fbfcf8;
+    --text: #1c2620;
+    --text-muted: #5c6b5f;
+    --border: #d7ddc9;
     --accent: #1f6f5c;
-    --assistant-bubble: #f0f1ef;
-    --assistant-text: #1b1d1e;
+    --accent-2: #c1652f;
+    --assistant-bubble: #fbfcf8;
+    --assistant-text: #1c2620;
     --user-bubble: var(--accent);
     --user-text: #ffffff;
     --error: #b3261e;
@@ -21,14 +26,15 @@
   }
   @media (prefers-color-scheme: dark) {
     :root {
-      --bg: #121416;
-      --panel: #17191b;
-      --text: #ecedee;
-      --text-muted: #9aa0a6;
-      --border: #2a2d2f;
+      --bg: #10160f;
+      --panel: #171f16;
+      --text: #e9ede4;
+      --text-muted: #8fa389;
+      --border: #29352a;
       --accent: #3fa98a;
-      --assistant-bubble: #23262a;
-      --assistant-text: #ecedee;
+      --accent-2: #e08a52;
+      --assistant-bubble: #1c2419;
+      --assistant-text: #e9ede4;
       --user-bubble: var(--accent);
       --user-text: #08130f;
       --error: #ff8a80;
@@ -51,7 +57,7 @@
 
   header {
     padding: 1.1rem 1.5rem 0.9rem;
-    border-bottom: 1px solid var(--border);
+    border-bottom: 2px dashed color-mix(in srgb, var(--accent-2) 55%, transparent);
     background: var(--panel);
   }
   header h1 {
@@ -98,11 +104,14 @@
     background: var(--user-bubble);
     color: var(--user-text);
     border-radius: 18px 18px 4px 18px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
   }
   .row.assistant .bubble {
     background: var(--assistant-bubble);
     color: var(--assistant-text);
     border-radius: 18px 18px 18px 4px;
+    border-left: 3px solid var(--accent-2);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
   }
   .row.assistant .bubble.error {
     background: var(--error-bubble);
@@ -128,7 +137,7 @@
     width: 6px;
     height: 6px;
     border-radius: 50%;
-    background: var(--text-muted);
+    background: var(--accent-2);
     animation: bounce 1.2s infinite ease-in-out;
   }
   .dots span:nth-child(2) { animation-delay: 0.15s; }
@@ -173,6 +182,13 @@
     background: var(--accent);
     color: var(--user-text);
     cursor: pointer;
+    transition: background-color 0.15s ease, transform 0.05s ease;
+  }
+  button:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--accent) 85%, black);
+  }
+  button:active:not(:disabled) {
+    transform: scale(0.97);
   }
   button:disabled {
     opacity: 0.5;

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -23,6 +23,10 @@
     --user-text: #ffffff;
     --error: #b3261e;
     --error-bubble: #fbeae8;
+    /* Traffic-light confidence indicator (modal only): green/amber/red. */
+    --conf-high: var(--accent);
+    --conf-medium: #b3841e;
+    --conf-low: var(--error);
   }
   @media (prefers-color-scheme: dark) {
     :root {
@@ -39,6 +43,9 @@
       --user-text: #08130f;
       --error: #ff8a80;
       --error-bubble: #3a1f1d;
+      --conf-high: var(--accent);
+      --conf-medium: #e3b34c;
+      --conf-low: var(--error);
     }
   }
 
@@ -180,6 +187,12 @@
     font-size: 0.82rem;
     line-height: 1.4;
     background: var(--bg);
+    cursor: pointer;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  }
+  .history-item:hover, .history-item:focus-visible {
+    border-color: var(--accent-2);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
   }
   .hi-top {
     display: flex;
@@ -389,6 +402,212 @@
     opacity: 0.5;
     cursor: default;
   }
+
+  /* Prediction detail popup: reasoning + citations for one sidebar entry. */
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(10, 14, 10, 0.45);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem;
+    z-index: 50;
+  }
+  .modal-backdrop.hidden { display: none; }
+
+  .modal {
+    background: var(--panel);
+    border-radius: 14px;
+    max-width: 560px;
+    width: 100%;
+    max-height: 85vh;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.28);
+    animation: modalIn 0.18s ease-out;
+  }
+  @keyframes modalIn {
+    from { transform: translateY(10px); opacity: 0; }
+    to { transform: translateY(0); opacity: 1; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .modal { animation: none; }
+  }
+  .modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 1.1rem 1.3rem 0.8rem;
+    border-bottom: 2px dashed color-mix(in srgb, var(--accent-2) 55%, transparent);
+    flex-shrink: 0;
+  }
+  .modal-header h3 {
+    margin: 0;
+    font-family: ui-serif, Georgia, "Times New Roman", serif;
+    font-size: 1.5rem;
+    font-weight: 700;
+  }
+  .modal-subtitle {
+    margin: 0.2rem 0 0;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    text-transform: capitalize;
+  }
+  .modal-close {
+    width: 26px;
+    height: 26px;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: transparent;
+    color: var(--text-muted);
+    font-size: 1.05rem;
+    line-height: 1;
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+  .modal-close:hover { background: var(--bg); color: var(--text); }
+
+  .modal-body {
+    overflow-y: auto;
+    padding: 1.1rem 1.3rem 1.4rem;
+    font-size: 0.9rem;
+    line-height: 1.55;
+  }
+  /* Hero figures: AAV and duration are the headline, biggest text in the
+     popup. Total sits in the same row, set apart by a divider and pushed to
+     the right; everything else (range, confidence) is a smaller sub-item. */
+  .modal-hero {
+    display: flex;
+    align-items: stretch;
+    gap: 1.8rem;
+    margin-bottom: 0.7rem;
+  }
+  .hero-divider {
+    width: 1px;
+    background: var(--border);
+    align-self: stretch;
+    /* Equal auto margins split the flex row's free space evenly on both
+       sides, centering the line between the AAV/Years cluster and Total
+       (which then sits flush at the right edge with no space left for it). */
+    margin-left: auto;
+    margin-right: auto;
+  }
+  .hero-total {
+    text-align: right;
+  }
+  .hero-value {
+    font-family: ui-serif, Georgia, "Times New Roman", serif;
+    font-size: 2.1rem;
+    font-weight: 700;
+    line-height: 1.1;
+    font-variant-numeric: tabular-nums;
+    color: var(--text);
+  }
+  .hero-value.no-contract { font-size: 1.3rem; }
+  .hero-label {
+    margin-top: 0.2rem;
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-muted);
+  }
+  /* Range chart: aav_low--aav_high as a track, with a dot at the predicted
+     AAV's actual scaled position -- not just the two numbers as text. */
+  .range-chart {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    margin: 0.5rem 0 1rem;
+  }
+  .range-endpoint {
+    flex-shrink: 0;
+    font-size: 0.72rem;
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .range-track {
+    position: relative;
+    flex: 1;
+    height: 4px;
+    border-radius: 2px;
+    background: var(--border);
+  }
+  /* The dot doubles as the confidence indicator: color is the traffic
+     light (green/amber/red) instead of a separate confidence bubble. */
+  .range-dot {
+    position: absolute;
+    top: 50%;
+    width: 11px;
+    height: 11px;
+    border-radius: 50%;
+    background: var(--text-muted);
+    border: 2px solid var(--panel);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+    transform: translate(-50%, -50%);
+  }
+  .range-dot.high { background: var(--conf-high); }
+  .range-dot.medium { background: var(--conf-medium); }
+  .range-dot.low { background: var(--conf-low); }
+  .confidence-label {
+    margin: -0.7rem 0 0.9rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-align: right;
+  }
+  .confidence-label.high { color: var(--conf-high); }
+  .confidence-label.medium { color: var(--conf-medium); }
+  .confidence-label.low { color: var(--conf-low); }
+  .modal-section-title {
+    margin: 1.1rem 0 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-muted);
+  }
+  .modal-body p { margin: 0; }
+  .citation {
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 0.6rem 0.75rem;
+    margin-bottom: 0.55rem;
+  }
+  .citation-badge {
+    display: inline-block;
+    font-size: 0.66rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    padding: 0.12rem 0.45rem;
+    border-radius: 999px;
+    margin-bottom: 0.35rem;
+  }
+  .citation-badge.tool {
+    background: color-mix(in srgb, var(--accent) 18%, transparent);
+    color: var(--accent);
+  }
+  .citation-badge.model_knowledge {
+    background: color-mix(in srgb, var(--text-muted) 22%, transparent);
+    color: var(--text-muted);
+  }
+  .citation-claim { font-weight: 600; }
+  .citation-basis { color: var(--text-muted); margin-top: 0.2rem; font-size: 0.85rem; }
+  .citation-ref { color: var(--text-muted); margin-top: 0.3rem; font-size: 0.72rem; font-style: italic; }
+  .modal-meta {
+    margin-top: 1.2rem;
+    padding-top: 0.8rem;
+    border-top: 1px solid var(--border);
+    color: var(--text-muted);
+    font-size: 0.75rem;
+  }
+  .modal-error { color: var(--error); }
 </style>
 </head>
 <body>
@@ -412,6 +631,19 @@
       <button type="submit">Send</button>
     </form>
   </main>
+</div>
+
+<div id="modal-backdrop" class="modal-backdrop hidden">
+  <div class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+    <div class="modal-header">
+      <div>
+        <h3 id="modal-title">—</h3>
+        <p class="modal-subtitle" id="modal-subtitle"></p>
+      </div>
+      <button class="modal-close" id="modal-close" type="button" aria-label="Close">×</button>
+    </div>
+    <div class="modal-body" id="modal-body"></div>
+  </div>
 </div>
 
 <script>
@@ -449,12 +681,23 @@ function addBubble(role, text) {
 const historyList = document.getElementById("history-list");
 let knownRunIds = null; // null until the first successful load
 
+// Sub-$1M figures (pre-arb salaries are commonly $0.5-0.8M) read oddly as
+// "$0.5M" -- $XXXK matches how these are actually quoted/reported.
+function formatMoney(millions) {
+  const v = Number(millions);
+  if (Number.isNaN(v)) return "—";
+  if (Math.abs(v) < 1) {
+    return "$" + Math.round(v * 1000) + "K";
+  }
+  return "$" + v.toFixed(1) + "M";
+}
+
 function formatFigures(p) {
   if (p.no_contract === "True") return "No contract expected";
   const aav = parseFloat(p.predicted_aav);
   const dur = parseInt(p.predicted_duration, 10);
   if (Number.isNaN(aav) || Number.isNaN(dur)) return "—";
-  return "$" + aav.toFixed(1) + "M AAV · " + dur + (dur === 1 ? " yr" : " yrs");
+  return formatMoney(aav) + " AAV · " + dur + (dur === 1 ? " yr" : " yrs");
 }
 
 function formatDate(isoString) {
@@ -492,9 +735,150 @@ function renderHistory(predictions) {
       "  <span>·</span>" +
       "  <span>" + formatDate(p.run_date) + "</span>" +
       "</div>";
+    item.setAttribute("role", "button");
+    item.tabIndex = 0;
+    item.addEventListener("click", () => openTraceModal(p));
+    item.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        openTraceModal(p);
+      }
+    });
     historyList.appendChild(item);
   }
   knownRunIds = nextKnown;
+}
+
+// --- Prediction detail popup: reasoning + citations for one sidebar entry. ---
+const modalBackdrop = document.getElementById("modal-backdrop");
+const modalTitle = document.getElementById("modal-title");
+const modalSubtitle = document.getElementById("modal-subtitle");
+const modalBody = document.getElementById("modal-body");
+const modalClose = document.getElementById("modal-close");
+
+function escapeHtml(text) {
+  const div = document.createElement("div");
+  div.textContent = text == null ? "" : String(text);
+  return div.innerHTML;
+}
+
+function closeModal() {
+  modalBackdrop.classList.add("hidden");
+  modalBody.innerHTML = "";
+}
+modalClose.addEventListener("click", closeModal);
+modalBackdrop.addEventListener("click", (e) => {
+  if (e.target === modalBackdrop) closeModal();
+});
+document.addEventListener("keydown", (e) => {
+  if (e.key === "Escape" && !modalBackdrop.classList.contains("hidden")) closeModal();
+});
+
+function renderCitation(c) {
+  const isTool = c.source_type === "tool";
+  const badgeClass = isTool ? "tool" : "model_knowledge";
+  const badgeLabel = isTool ? "Tool" : "Model knowledge";
+  let refLine = "";
+  if (isTool && c.tool_name) {
+    refLine =
+      '<div class="citation-ref">via ' + escapeHtml(c.tool_name) +
+      (c.tool_call_ref ? " (ref: " + escapeHtml(c.tool_call_ref) + ")" : "") +
+      "</div>";
+  }
+  return (
+    '<div class="citation">' +
+    '<span class="citation-badge ' + badgeClass + '">' + badgeLabel + "</span>" +
+    '<div class="citation-claim">' + escapeHtml(c.claim) + "</div>" +
+    '<div class="citation-basis">' + escapeHtml(c.basis) + "</div>" +
+    refLine +
+    "</div>"
+  );
+}
+
+async function openTraceModal(p) {
+  modalTitle.textContent = p.player_name || p.player_id;
+  modalSubtitle.textContent = p.target_year + " · " + (p.phase || "");
+  modalBody.innerHTML = '<p class="modal-loading">Loading full reasoning and citations…</p>';
+  modalBackdrop.classList.remove("hidden");
+  modalClose.focus();
+
+  try {
+    const resp = await fetch("/api/trace/" + encodeURIComponent(p.run_id));
+    if (!resp.ok) {
+      modalBody.innerHTML = '<p class="modal-error">Couldn’t load this prediction’s trace.</p>';
+      return;
+    }
+    const trace = await resp.json();
+    const out = trace.structured_output || {};
+    const res = trace.phase_resolution || {};
+
+    let heroHtml;
+    let rangeHtml = "";
+    if (out.no_contract) {
+      heroHtml = '<div class="modal-hero"><div><div class="hero-value no-contract">No contract expected</div></div></div>';
+    } else {
+      heroHtml =
+        '<div class="modal-hero">' +
+        '<div><div class="hero-value">' + formatMoney(out.aav_millions) + "</div>" +
+        '<div class="hero-label">AAV</div></div>' +
+        '<div><div class="hero-value">' + out.duration_years + "</div>" +
+        '<div class="hero-label">' + (out.duration_years === 1 ? "Year" : "Years") + "</div></div>" +
+        '<div class="hero-divider"></div>' +
+        '<div class="hero-total"><div class="hero-value">' + formatMoney(out.total_value_millions) + "</div>" +
+        '<div class="hero-label">Total</div></div>' +
+        "</div>";
+
+      // Range chart: a track from aav_low to aav_high with a dot at the
+      // predicted AAV's actual position in that range. The dot doubles as
+      // the confidence indicator -- its color is the traffic light
+      // (green/amber/red) instead of a separate confidence bubble.
+      const low = Number(out.aav_low_millions);
+      const high = Number(out.aav_high_millions);
+      const aav = Number(out.aav_millions);
+      let pct = 50;
+      if (high > low) {
+        pct = Math.max(0, Math.min(100, ((aav - low) / (high - low)) * 100));
+      }
+      const confClass = out.confidence ? String(out.confidence).toLowerCase() : "";
+      const confTitle = out.confidence ? " (" + out.confidence + " confidence)" : "";
+      rangeHtml =
+        '<div class="range-chart" title="Projected ' + formatMoney(aav) + " within range " +
+        formatMoney(low) + "–" + formatMoney(high) + confTitle + '">' +
+        '<span class="range-endpoint">' + formatMoney(low) + "</span>" +
+        '<div class="range-track"><div class="range-dot ' + confClass + '" style="left: ' + pct.toFixed(1) + '%;"></div></div>' +
+        '<span class="range-endpoint">' + formatMoney(high) + "</span>" +
+        "</div>" +
+        (out.confidence
+          ? '<div class="confidence-label ' + confClass + '">' + escapeHtml(out.confidence) + " confidence</div>"
+          : "");
+    }
+
+    const citations = out.citations || [];
+    const citationsHtml = citations.length
+      ? citations.map(renderCitation).join("")
+      : "<p>No citations recorded for this prediction.</p>";
+    const notesHtml = (res.notes || []).length
+      ? '<div class="modal-section-title">Phase resolution notes</div><p>' +
+        res.notes.map(escapeHtml).join("<br>") + "</p>"
+      : "";
+    const arithmeticHtml = trace.arithmetic_note
+      ? '<div class="modal-section-title">Arithmetic check</div><p>' + escapeHtml(trace.arithmetic_note) + "</p>"
+      : "";
+
+    modalBody.innerHTML =
+      heroHtml +
+      rangeHtml +
+      '<div class="modal-section-title">Reasoning</div>' +
+      "<p>" + escapeHtml(out.reasoning || "") + "</p>" +
+      notesHtml +
+      arithmeticHtml +
+      '<div class="modal-section-title">Citations (' + citations.length + ")</div>" +
+      citationsHtml +
+      '<div class="modal-meta">Run ' + formatDate(trace.run_date) + " · " + escapeHtml(trace.model_id) +
+      " · prompt " + escapeHtml(trace.prompt_version) + "</div>";
+  } catch (err) {
+    modalBody.innerHTML = '<p class="modal-error">Error loading trace: ' + escapeHtml(String(err)) + "</p>";
+  }
 }
 
 async function refreshHistory() {

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -573,6 +573,17 @@
     color: var(--text-muted);
   }
   .modal-body p { margin: 0; }
+  .modal-body p + p { margin-top: 0.6rem; }
+  .reasoning-list {
+    margin: 0.6rem 0 0;
+    padding-left: 1.15rem;
+  }
+  .reasoning-list li {
+    margin-bottom: 0.5rem;
+  }
+  .reasoning-list li:last-child {
+    margin-bottom: 0;
+  }
   .citation {
     border: 1px solid var(--border);
     border-radius: 10px;
@@ -762,6 +773,33 @@ function escapeHtml(text) {
   return div.innerHTML;
 }
 
+// The model's reasoning is one long string with no real structure -- it
+// sometimes writes bullets inline as "... - Label: detail - Label: detail"
+// instead of line breaks, which renders as one dense wall of text otherwise.
+// Split on real newlines first (paragraphs), then on that inline-bullet
+// pattern within each paragraph, into an intro + a <ul>. Falls back to a
+// single paragraph untouched when neither pattern is present.
+function formatReasoningParagraph(text) {
+  const parts = text.split(/\s-\s(?=[A-Z][^:]{2,50}:\s)/);
+  const intro = parts[0].trim();
+  const bullets = parts.slice(1).map((s) => s.trim()).filter(Boolean);
+  let html = intro ? "<p>" + escapeHtml(intro) + "</p>" : "";
+  if (bullets.length) {
+    html += '<ul class="reasoning-list">' + bullets.map((b) => "<li>" + escapeHtml(b) + "</li>").join("") + "</ul>";
+  }
+  return html;
+}
+
+function formatReasoning(text) {
+  if (!text) return "";
+  return text
+    .split(/\n+/)
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map(formatReasoningParagraph)
+    .join("");
+}
+
 function closeModal() {
   modalBackdrop.classList.add("hidden");
   modalBody.innerHTML = "";
@@ -869,7 +907,7 @@ async function openTraceModal(p) {
       heroHtml +
       rangeHtml +
       '<div class="modal-section-title">Reasoning</div>' +
-      "<p>" + escapeHtml(out.reasoning || "") + "</p>" +
+      formatReasoning(out.reasoning) +
       notesHtml +
       arithmeticHtml +
       '<div class="modal-section-title">Citations (' + citations.length + ")</div>" +

--- a/web/status.py
+++ b/web/status.py
@@ -1,0 +1,47 @@
+"""Per-session status tracking for the chat UI's "what's happening" indicator.
+
+A HookProvider that watches which top-level tool the orchestrator agent is
+calling -- it only has two: intake_tool (resolves player/year/mode) and
+predict_tool (runs the actual prediction) -- and records a user-facing phase
+string per session. The frontend polls GET /api/status while a POST
+/api/chat call is in flight to show something better than a static
+"Thinking..." the whole time.
+
+Deliberately lives in web/, not agent/: this exists purely to narrate
+progress to the UI, it isn't part of the orchestrator's own behavior.
+"""
+
+from strands.hooks import BeforeToolCallEvent, HookProvider, HookRegistry
+
+DEFAULT_STATUS = "Thinking..."
+
+_PHASE_LABELS = {
+    "intake_tool": "Looking up player...",
+    "predict_tool": "Making prediction...",
+}
+
+# session_id -> current status string
+_status = {}
+
+
+class StatusHook(HookProvider):
+    """Records the friendly phase label for whichever tool call just started."""
+
+    def __init__(self, session_id):
+        self._session_id = session_id
+
+    def register_hooks(self, registry: HookRegistry) -> None:
+        registry.add_callback(BeforeToolCallEvent, self._on_before)
+
+    def _on_before(self, event: BeforeToolCallEvent) -> None:
+        label = _PHASE_LABELS.get(event.tool_use.get("name", ""))
+        if label:
+            _status[self._session_id] = label
+
+
+def get_status(session_id):
+    return _status.get(session_id, DEFAULT_STATUS)
+
+
+def reset_status(session_id):
+    _status[session_id] = DEFAULT_STATUS

--- a/web/traces.py
+++ b/web/traces.py
@@ -1,0 +1,39 @@
+"""Loads a single prediction trace for the sidebar's detail popup.
+
+Returns a trimmed subset of the full trace JSON (agent/trace.py:write_trace)
+-- reasoning, citations, predicted figures, phase resolution -- not the full
+thing (system_prompt/messages/usage), which is large and meant for deep
+debugging, not an at-a-glance popup.
+
+run_id is client-supplied (it comes from the sidebar list), so it's validated
+against the same charset new_run_id() actually produces before touching the
+filesystem -- this is the one place user input reaches a file path, and
+"pass whatever string you like" would let a request read arbitrary files.
+"""
+
+import json
+import re
+
+from agent.config import TRACES_DIR
+
+_RUN_ID_RE = re.compile(r"^[A-Za-z0-9_]+$")
+
+
+def load_trace_summary(run_id):
+    """Returns a trimmed trace dict, or None if run_id is invalid or not found."""
+    if not _RUN_ID_RE.match(run_id):
+        return None
+    path = TRACES_DIR / f"{run_id}.json"
+    if not path.exists():
+        return None
+    with open(path) as file:
+        trace = json.load(file)
+    return {
+        "run_id": trace.get("run_id"),
+        "run_date": trace.get("run_date"),
+        "model_id": trace.get("model_id"),
+        "prompt_version": trace.get("prompt_version"),
+        "phase_resolution": trace.get("phase_resolution"),
+        "structured_output": trace.get("structured_output"),
+        "arithmetic_note": trace.get("arithmetic_note"),
+    }


### PR DESCRIPTION
## Summary

Adds a minimal local web UI over the existing `agent/orchestrator` chat agent — a chat window plus a sidebar of every prediction the agent has generated, with a detail popup showing full reasoning and citations per prediction. Lives entirely in a new top-level `web/` package so it stays a thin consumer of `agent/`, not part of its business logic (mirrors the relationship `agent/ask.py`'s CLI already has). Along the way, found and fixed two real bugs in existing agent code (not just frontend polish — see below).

Run it locally with:

```
make web
```

then open `http://localhost:8000/`. Requires `OPENAI_API_KEY` in `.env`, same as `make ask`.

## What's new

### Backend (`web/`)

- **`web/server.py`** — FastAPI app, deliberately minimal for a first local pass:
  - `GET /` — serves the static chat page.
  - `POST /api/chat` — one-turn-per-request adapter around the orchestrator. Each browser session gets its own persistent `Agent` instance (Design Decision #7: the orchestrator is the one non-fresh agent in the system), kept in an in-memory dict keyed by a client-generated `session_id`.
  - `GET /api/status?session_id=...` — polled while a chat request is in flight, to show which phase the agent is in.
  - `GET /api/history` — every prediction ever made (`predictions/history.csv`), newest first.
  - `GET /api/trace/{run_id}` — a trimmed version of one prediction's full trace JSON (reasoning, citations, predicted figures, phase resolution) for the detail popup.
  - No auth, no multi-worker support, no rate limiting — localhost dev tool only, documented as such in the module docstring.
- **`web/status.py`** — a `StatusHook` (`HookProvider`) that watches the orchestrator's `BeforeToolCallEvent`s and records a friendly phase label per session: `intake_tool` → "Looking up player...", `predict_tool` → "Making prediction...", anything else → "Thinking...". Exact, not guessed, since those are the orchestrator's only two tools.
- **`web/history.py`** — reads `predictions/history.csv` (not the trace JSONs — already the right shape, far cheaper to read than opening 70+ multi-KB trace files) and joins in player names from `players.csv`.
- **`web/traces.py`** — loads one trace JSON by `run_id` for the detail popup. `run_id` is validated against a strict charset before touching the filesystem (it's client-supplied), so it can't be used for path traversal — verified with a live `../../etc/passwd`-style request, which 404s.

### Frontend (`web/static/index.html`)

Single self-contained file, no build step, no external dependencies (system fonts only):

- Two-pane layout: a full-width header at the top, a collapsible "Predictions" sidebar on the left (with a fold/unfold handle that tracks the sidebar's edge as it animates shut), and the chat on the right with its own "Chat" header.
- iMessage/Claude-style chat bubbles (user right-aligned, assistant left-aligned), with a typing indicator that appears in-place where the reply will land — three bouncing dots plus a live phase caption from `/api/status`.
- A "scorebook" visual identity (pale sage ledger-paper background, ink-navy text, pine green primary accent, a sparing terracotta secondary accent for stitching/tab details) instead of default light-gray chrome, including custom scrollbar styling.
- Sidebar: every prediction (player, year, phase, predicted figures, a confidence dot), polled every 5s so predictions made anywhere — another terminal, a backtest run — show up, not just this tab's own. A genuinely new entry pops in with a brief highlight animation.
- Clicking a sidebar entry opens a detail popup: player/year header, a hero row (AAV and duration as the biggest figures, Total set apart by a divider and right-aligned), a range chart (a track from `aav_low` to `aav_high` with a dot at the actual predicted AAV's scaled position — the dot's color doubles as the confidence indicator, green/amber/red), then full reasoning and every citation (badged Tool vs. Model knowledge, with the tool name/ref for tool-sourced ones).
- Reasoning text (both in the popup and in chat replies) gets lightweight structure instead of rendering as one dense paragraph: split into real paragraphs, and inline "`- Label: detail`" bullet patterns (how the model often writes reasoning) get broken into an actual `<ul>`.
- Sub-$1M figures render as `$XXXK` instead of `$0.5M` (caught via a real pre-arb example, Wittgren).
- Respects `prefers-color-scheme` (light/dark) and `prefers-reduced-motion` throughout.

## Bugs found and fixed along the way

These aren't frontend changes — they're real issues in existing `agent/` code, surfaced by building something that actually reads `predictions/history.csv` and drives the orchestrator turn-by-turn outside the CLI's `input()` loop.

1. **`predictions/history.csv` schema corruption** (`agent/trace.py`). `HISTORY_HEADERS` gained a `no_contract` column mid-project, but the header line is only written once, when the file doesn't exist yet. The existing file's header silently stopped matching the rows being appended to it — 66 of 73 rows had 16 fields against a 15-field header, so every field after `phase` was shifted by one for most of the file. Migrated the existing file to a consistent schema, and `append_history()` now raises loudly if the stored header doesn't match `HISTORY_HEADERS` instead of silently misaligning every row from then on.
2. **Orchestrator occasionally leaking raw JSON into chat replies** (`agent/orchestrator/agent.py`, `agent/orchestrator/prompts.py`). Despite the system prompt's explicit "never show raw JSON" instruction, gpt-5-mini was observed serializing `predict_tool`'s structured result straight into the user-facing `message` field instead of paraphrasing it in prose. Fixed two ways: a stronger prompt rule with a wrong/right example, and a code-level guard (`get_turn()`) that detects a JSON-shaped `message` and does one corrective retry on the same persistent agent before giving up — prompt text alone wasn't reliable enough. `get_turn()` is now shared by both the CLI loop and the web server's chat handler, so the fix applies in both places.

## Other changes

- `agent/orchestrator/agent.py`: `create_orchestrator_agent()` gained an optional `extra_hooks` param (used by the web server to attach `StatusHook` per session) — additive, CLI behavior unchanged.
- `Makefile`: new `web` target (`make web`).
- `requirements.txt`: added `fastapi`, `uvicorn`.

## Test plan

- `make test-agent` — all 122 existing tests pass unchanged.
- Manual: `make web`, hard-refresh, and exercise:
  - [ ] Asking a question end-to-end (clarifying question → prediction → follow-up)
  - [ ] Sidebar populates and a new prediction pops to the top
  - [ ] Clicking a sidebar entry opens the popup with correct figures, range chart, and citations
  - [ ] Sidebar fold/unfold animation
  - [ ] Light/dark mode
- Not yet tested: behavior under multiple concurrent browser sessions beyond basic sanity, and long-running conversation sessions (no per-session turn cap wired into the web server yet — see Known limitations).

## Known limitations / follow-ups

- In-memory sessions only — lost on server restart, no multi-worker support.
- No auth, no rate limiting, no HTTPS — localhost only, by design for now.
- No per-session turn/clarification-streak cap in the web server (the CLI's `MAX_TURNS`/`MAX_CONVERSATION_TURNS` guards aren't wired in here) — a long confused conversation just keeps calling the LLM.
- No incremental conversation-trace persistence — `agent/ask.py` writes a trace at the end of a CLI conversation; the web server doesn't write one at all yet, so an abandoned browser session leaves no trace.
- Sidebar surfaces `make backtest-agent` runs too, not just interactive ones (both write to `history.csv`) — not filtered out, could get noisy.
- Sidebar fold state isn't persisted across page reloads.